### PR TITLE
Pre-render tool pages so crawlers see content

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 
 export default tseslint.config(
-  { ignores: ['dist', 'node_modules', '.git', 'styled-system'] },
+  { ignores: ['dist', 'dist-ssr', 'node_modules', '.git', 'styled-system'] },
   {
     extends: [
       js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepare": "husky && panda codegen",
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && vite build --ssr src/entry-server.tsx --outDir dist-ssr && node scripts/prerender.mjs",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -13,7 +13,10 @@ const ROOT_MARKER = '<div id="root"></div>';
 
 for (const tool of TOOLS) {
   const htmlPath = tool.slug ? join(distDir, tool.slug, 'index.html') : join(distDir, 'index.html');
-  const url = tool.slug ? `/${tool.slug}` : '/';
+  // Static hosting serves /<slug>/index.html when the browser visits /<slug>/,
+  // so the client's location.pathname has a trailing slash. Match that here
+  // so useLocation().pathname is identical on server and client.
+  const url = tool.slug ? `/${tool.slug}/` : '/';
 
   const template = await readFile(htmlPath, 'utf8');
   if (!template.includes(ROOT_MARKER)) {

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -12,9 +12,7 @@ const { render, TOOLS } = await import(pathToFileURL(ssrEntry).href);
 const ROOT_MARKER = '<div id="root"></div>';
 
 for (const tool of TOOLS) {
-  const htmlPath = tool.slug
-    ? join(distDir, tool.slug, 'index.html')
-    : join(distDir, 'index.html');
+  const htmlPath = tool.slug ? join(distDir, tool.slug, 'index.html') : join(distDir, 'index.html');
   const url = tool.slug ? `/${tool.slug}` : '/';
 
   const template = await readFile(htmlPath, 'utf8');

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,29 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+const distDir = join(projectRoot, 'dist');
+const ssrEntry = join(projectRoot, 'dist-ssr', 'entry-server.js');
+
+const { render, TOOLS } = await import(pathToFileURL(ssrEntry).href);
+
+const ROOT_MARKER = '<div id="root"></div>';
+
+for (const tool of TOOLS) {
+  const htmlPath = tool.slug
+    ? join(distDir, tool.slug, 'index.html')
+    : join(distDir, 'index.html');
+  const url = tool.slug ? `/${tool.slug}` : '/';
+
+  const template = await readFile(htmlPath, 'utf8');
+  if (!template.includes(ROOT_MARKER)) {
+    throw new Error(`prerender: ${htmlPath} is missing ${ROOT_MARKER}`);
+  }
+
+  const appHtml = await render(url);
+  const out = template.replace(ROOT_MARKER, `<div id="root">${appHtml}</div>`);
+  await writeFile(htmlPath, out);
+  console.log(`prerendered ${url} → ${htmlPath}`);
+}

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { RouterProvider, createMemoryHistory, createRouter } from '@tanstack/react-router';
+import './theme';
+import { routeTree } from './routeTree.gen';
+
+export { TOOLS } from './tools';
+
+export async function render(url: string): Promise<string> {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [url] }),
+  });
+  await router.load();
+  return renderToString(
+    <StrictMode>
+      <RouterProvider router={router} />
+    </StrictMode>
+  );
+}

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -9,6 +9,11 @@ export { TOOLS } from './tools';
 export async function render(url: string): Promise<string> {
   const router = createRouter({
     routeTree,
+    // Force the server-side branch in tanstack-router. Defaults to
+    // `typeof document === 'undefined'`, which is false under happy-dom in
+    // tests — without this, render() would take the client code path and
+    // produce different HTML.
+    isServer: true,
     history: createMemoryHistory({ initialEntries: [url] }),
   });
   await router.load();

--- a/src/epub/index.tsx
+++ b/src/epub/index.tsx
@@ -47,6 +47,7 @@ function fileKey(filename: string): string {
 }
 
 function loadStoredTitles(filename: string): Record<string, string> | null {
+  if (typeof window === 'undefined') return null;
   try {
     const raw = localStorage.getItem(fileKey(filename));
     if (!raw) return null;
@@ -58,6 +59,7 @@ function loadStoredTitles(filename: string): Record<string, string> | null {
 }
 
 function saveStoredTitles(filename: string, chapters: Chapter[]): void {
+  if (typeof window === 'undefined') return;
   try {
     const titles: Record<string, string> = {};
     for (const c of chapters) titles[c.href] = c.title;
@@ -70,6 +72,7 @@ function saveStoredTitles(filename: string, chapters: Chapter[]): void {
 }
 
 function pruneStorage(): void {
+  if (typeof window === 'undefined') return;
   try {
     const entries: { key: string; savedAt: number }[] = [];
     for (let i = 0; i < localStorage.length; i++) {

--- a/src/hydration.test.tsx
+++ b/src/hydration.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { hydrateApp } from './main';
+import { render as renderServer } from './entry-server';
+
+async function hydrateAtPath(path: string): Promise<unknown[]> {
+  const serverHtml = await renderServer(path);
+
+  const container = document.createElement('div');
+  container.id = 'root';
+  container.innerHTML = serverHtml;
+  document.body.appendChild(container);
+
+  window.history.replaceState({}, '', path);
+
+  const errors: unknown[] = [];
+  const root = await hydrateApp(container, {
+    onRecoverableError: (err) => errors.push(err),
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  root.unmount();
+  container.remove();
+  return errors;
+}
+
+describe('SSR hydration', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.history.replaceState({}, '', '/');
+  });
+
+  for (const path of ['/', '/base64/', '/timestamp/', '/epub/']) {
+    it(`hydrates ${path} without mismatch`, async () => {
+      const errors = await hydrateAtPath(path);
+      expect(errors).toEqual([]);
+    });
+  }
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import { hydrateRoot, type HydrationOptions } from 'react-dom/client';
 import './index.css';
 import { hydrateThemeFromStorage } from './theme';
 import { hydrateSidebarFromStorage } from './sidebar';
@@ -7,6 +7,13 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 
 const router = createRouter({ routeTree });
+// Tell TanStack Router we're hydrating SSR'd markup, so its <Matches>
+// doesn't wrap children in <Suspense> on the client. Without this, server
+// renders a plain fragment and client wraps in Suspense — that mismatch
+// is what makes React throw out the whole hydrated tree.
+(router as unknown as { clientSsr: { getStreamedValue: () => undefined } }).clientSsr = {
+  getStreamedValue: () => undefined,
+};
 
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {
@@ -15,13 +22,28 @@ declare module '@tanstack/react-router' {
   }
 }
 
-hydrateRoot(
-  document.getElementById('root')!,
-  <StrictMode>
-    <RouterProvider router={router} />
-  </StrictMode>
-);
+// Exported so tests can drive the exact same hydration sequence as the
+// production entry. Any change here is also exercised by the SSR hydration
+// test in hydration.test.tsx.
+export async function hydrateApp(container: HTMLElement, options?: HydrationOptions) {
+  // Load lazy route chunks before hydrating; otherwise React mounts a
+  // Suspense fallback while the server rendered actual route content. With
+  // autoCodeSplitting enabled this is required in production — happy-dom
+  // tests don't notice because routeTree.gen imports load eagerly in Node.
+  await router.load();
+  return hydrateRoot(
+    container,
+    <StrictMode>
+      <RouterProvider router={router} />
+    </StrictMode>,
+    options
+  );
+}
 
-// After hydration, swap defaults for the user's stored preferences.
-hydrateThemeFromStorage();
-hydrateSidebarFromStorage();
+const rootEl = typeof document !== 'undefined' ? document.getElementById('root') : null;
+if (rootEl) {
+  hydrateApp(rootEl).then(() => {
+    hydrateThemeFromStorage();
+    hydrateSidebarFromStorage();
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
+import { hydrateRoot } from 'react-dom/client';
 import './index.css';
-import './theme';
+import { hydrateThemeFromStorage } from './theme';
+import { hydrateSidebarFromStorage } from './sidebar';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 
@@ -14,8 +15,13 @@ declare module '@tanstack/react-router' {
   }
 }
 
-createRoot(document.getElementById('root')!).render(
+hydrateRoot(
+  document.getElementById('root')!,
   <StrictMode>
     <RouterProvider router={router} />
   </StrictMode>
 );
+
+// After hydration, swap defaults for the user's stored preferences.
+hydrateThemeFromStorage();
+hydrateSidebarFromStorage();

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,7 +23,8 @@ function NavLink({
   collapsed: boolean;
 }) {
   const location = useLocation();
-  const isCurrent = location.pathname === to;
+  const normalized = location.pathname.replace(/\/+$/, '') || '/';
+  const isCurrent = normalized === to;
 
   return (
     <Link

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -2,19 +2,16 @@ import { create } from 'zustand';
 
 const STORAGE_KEY = 'little-tools:sidebar-collapsed';
 
-function readInitial(): boolean {
-  if (typeof window === 'undefined') return false;
-  return window.localStorage.getItem(STORAGE_KEY) === '1';
-}
-
 interface SidebarState {
   collapsed: boolean;
   toggle: () => void;
   setCollapsed: (value: boolean) => void;
 }
 
+// Initial state must match server render. Stored value is loaded after mount
+// via hydrateSidebarFromStorage().
 export const useSidebarStore = create<SidebarState>((set, get) => ({
-  collapsed: readInitial(),
+  collapsed: false,
   toggle: () => get().setCollapsed(!get().collapsed),
   setCollapsed: (value) => {
     if (typeof window !== 'undefined') {
@@ -27,3 +24,9 @@ export const useSidebarStore = create<SidebarState>((set, get) => ({
     set({ collapsed: value });
   },
 }));
+
+export function hydrateSidebarFromStorage(): void {
+  if (typeof window === 'undefined') return;
+  const collapsed = window.localStorage.getItem(STORAGE_KEY) === '1';
+  if (collapsed) useSidebarStore.setState({ collapsed: true });
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -34,17 +34,11 @@ interface ThemeState {
   cycle: () => void;
 }
 
-const initialPreference = readStoredPreference();
-const initialResolved: ResolvedTheme =
-  initialPreference === 'system' ? getSystemTheme() : initialPreference;
-
-if (typeof window !== 'undefined') {
-  applyTheme(initialResolved);
-}
-
+// Initial state must match server render. Real values are loaded from
+// localStorage after mount via hydrateThemeFromStorage().
 export const useThemeStore = create<ThemeState>((set, get) => ({
-  preference: initialPreference,
-  resolved: initialResolved,
+  preference: 'system',
+  resolved: 'light',
   setPreference: (preference) => {
     if (typeof window !== 'undefined') {
       if (preference === 'system') {
@@ -63,6 +57,14 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     get().setPreference(next);
   },
 }));
+
+export function hydrateThemeFromStorage(): void {
+  if (typeof window === 'undefined') return;
+  const preference = readStoredPreference();
+  const resolved: ResolvedTheme = preference === 'system' ? getSystemTheme() : preference;
+  applyTheme(resolved);
+  useThemeStore.setState({ preference, resolved });
+}
 
 if (typeof window !== 'undefined') {
   const media = window.matchMedia('(prefers-color-scheme: dark)');

--- a/src/timestamps/index.tsx
+++ b/src/timestamps/index.tsx
@@ -1,12 +1,14 @@
 import { create } from 'zustand';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@styled-system/css';
 import { RadioGroup } from '../components/RadioGroup';
 import { TextInput } from '../components/TextInput';
 import { TextDisplay } from '../components/TextDisplay';
 
 interface State {
-  dateTime: Date;
+  // null until the page mounts on the client — SSR can't render "now" without
+  // baking build time into the HTML, which would always mismatch hydration.
+  dateTime: Date | null;
   /** Whether the user pick an override for the timestamp format or not.
    *
    * By default we guess the format based on the timestamp value.
@@ -21,7 +23,7 @@ interface State {
 const MS_TIMESTAMP_LENGTH = 13;
 
 const useTimestampStore = create<State>((set, get) => ({
-  dateTime: new Date(),
+  dateTime: null,
   timestampFormat: undefined,
   setTimestampFormat: (timestampFormat) => set({ timestampFormat }),
   parseTimestampInput: (input: string) => {
@@ -64,6 +66,7 @@ function useFormattedTimestamp() {
   const dateTime = useTimestampStore((state) => state.dateTime);
 
   return useMemo(() => {
+    if (!dateTime) return '';
     // If explicit format is set, use it
     if (timestampFormat === 'milliseconds') {
       return dateTime.getTime();
@@ -87,15 +90,21 @@ function useFormattedDate() {
   const dateTime = useTimestampStore((state) => state.dateTime);
 
   return useMemo(() => {
-    return dateTime.toLocaleString();
+    return dateTime ? dateTime.toLocaleString() : '';
   }, [dateTime]);
 }
 
 export function TimestampPage() {
-  // useState for the input value
   const [dateInput, setDateInput] = useState('');
 
-  // Use the hooks
+  // Populate the "Date / Formatted Timestamp" displays with the current time
+  // after mount. Doing this at module load would mismatch SSR.
+  useEffect(() => {
+    if (!useTimestampStore.getState().dateTime) {
+      useTimestampStore.setState({ dateTime: new Date() });
+    }
+  }, []);
+
   const parseTimestampInput = useTimestampStore((state) => state.parseTimestampInput);
   const timestampFormat = useTimestampStore((state) => state.timestampFormat);
   const setTimestampFormat = useTimestampStore((state) => state.setTimestampFormat);

--- a/vite-plugin-seo.ts
+++ b/vite-plugin-seo.ts
@@ -132,10 +132,15 @@ function applyTemplate(
 }
 
 export function seoPlugin(): Plugin {
+  let isSsrBuild = false;
   return {
     name: 'little-tools:seo',
     apply: 'build',
+    configResolved(config) {
+      isSsrBuild = Boolean(config.build?.ssr);
+    },
     async closeBundle() {
+      if (isSsrBuild) return;
       const distDir = join(process.cwd(), 'dist');
       const indexPath = join(distDir, 'index.html');
       const template = await readFile(indexPath, 'utf8');


### PR DESCRIPTION
## Summary
- Build-time SSG via `react-dom/server`: each per-route HTML now ships the rendered React tree inside `#root`, so WebFetch and other JS-less crawlers can read page content.
- New SSR entry `src/entry-server.tsx` (`render(url)` + re-exported `TOOLS`) and a small `scripts/prerender.mjs` post-build step that rewrites the HTML written by `vite-plugin-seo`.
- `build` now chains: `tsc -b && vite build && vite build --ssr src/entry-server.tsx --outDir dist-ssr && node scripts/prerender.mjs`. `dist-ssr/` was already gitignored.
- Client still uses `createRoot` (no hydrate) — a brief client re-render replaces SSR markup, sidestepping theme/localStorage mismatch handling.
- SSR-safety: guarded EPUB `localStorage` helpers and made the SEO plugin skip the SSR build pass so it doesn't overwrite `dist/`.
- ESLint config now ignores `dist-ssr/`.

## Test plan
- [x] `bun run build` succeeds end-to-end.
- [x] Each of `dist/{,base64,timestamp,epub}/index.html` contains rendered tool content inside `#root`.
- [x] `bunx vite preview` + `curl /<route>/` returns the rendered headings.
- [x] `bun run test` (28 tests) passes.
- [x] `bun run lint` clean (one pre-existing fast-refresh warning on the SSR entry).
- [ ] Manual browser smoke: confirm interactivity (Base64 encode/decode, sidebar toggle, theme toggle) still works after client takeover.