### PR TITLE
EPUB renamer: detect Scrivener heading paragraphs, add level selector

### DIFF
--- a/src/epub/index.tsx
+++ b/src/epub/index.tsx
@@ -7,9 +7,11 @@ import { TextInput } from '../components/TextInput';
 import { EpubDocument, Chapter } from './parser';
 
 const LOAD_HEADINGS_TOOLTIP =
-  'Find the first heading in each chapter and set it as the chapter name.';
+  'Find the first heading in each chapter and set it as the chapter name. Chapters without a matching heading keep their existing name.';
 
 type Status = 'idle' | 'loading' | 'loaded' | 'saving' | 'loading-headings';
+
+export type HeadingLevelChoice = 'any' | '1' | '2' | '3' | '4' | '5' | '6';
 
 interface State {
   doc: EpubDocument | null;
@@ -17,11 +19,13 @@ interface State {
   filename: string;
   status: Status;
   error: string | null;
+  headingLevel: HeadingLevelChoice;
 
   loadFile: (file: File) => Promise<void>;
   updateChapterTitle: (id: string, title: string) => void;
   saveEpub: () => Promise<void>;
   loadFromHeadings: () => Promise<void>;
+  setHeadingLevel: (level: HeadingLevelChoice) => void;
   reset: () => void;
 }
 
@@ -117,6 +121,7 @@ const useEpubStore = create<State>((set, get) => ({
   filename: '',
   status: 'idle',
   error: null,
+  headingLevel: 'any',
 
   loadFile: async (file: File) => {
     if (!isEpubFile(file)) {
@@ -169,14 +174,15 @@ const useEpubStore = create<State>((set, get) => ({
   },
 
   loadFromHeadings: async () => {
-    const { doc, chapters, status, filename } = get();
+    const { doc, chapters, status, filename, headingLevel } = get();
     if (!doc || status !== 'loaded') return;
     set({ status: 'loading-headings', error: null });
     try {
+      const level = headingLevel === 'any' ? undefined : Number(headingLevel);
       const updated: Chapter[] = [];
       let foundAny = false;
       for (const c of chapters) {
-        const heading = await doc.getChapterHeading(c.id);
+        const heading = await doc.getChapterHeading(c.id, { level });
         if (heading && heading.length > 0) {
           updated.push({ ...c, title: heading });
           foundAny = true;
@@ -196,8 +202,17 @@ const useEpubStore = create<State>((set, get) => ({
     }
   },
 
+  setHeadingLevel: (level) => set({ headingLevel: level }),
+
   reset: () => {
-    set({ doc: null, chapters: [], filename: '', status: 'idle', error: null });
+    set({
+      doc: null,
+      chapters: [],
+      filename: '',
+      status: 'idle',
+      error: null,
+      headingLevel: 'any',
+    });
   },
 }));
 
@@ -430,10 +445,12 @@ export function EpubPage() {
   const filename = useEpubStore((s) => s.filename);
   const status = useEpubStore((s) => s.status);
   const error = useEpubStore((s) => s.error);
+  const headingLevel = useEpubStore((s) => s.headingLevel);
   const loadFile = useEpubStore((s) => s.loadFile);
   const updateChapterTitle = useEpubStore((s) => s.updateChapterTitle);
   const saveEpub = useEpubStore((s) => s.saveEpub);
   const loadFromHeadings = useEpubStore((s) => s.loadFromHeadings);
+  const setHeadingLevel = useEpubStore((s) => s.setHeadingLevel);
   const reset = useEpubStore((s) => s.reset);
 
   const isBusy = status === 'loading' || status === 'saving' || status === 'loading-headings';
@@ -494,16 +511,24 @@ export function EpubPage() {
             <div className={css({ fontWeight: 'medium' })}>File:</div>
             <div className={css({ fontFamily: 'mono', fontSize: 'sm' })}>{filename}</div>
           </div>
+
           <div
             className={css({
               display: 'flex',
-              flexDir: 'row',
-              alignItems: 'center',
-              gap: '2',
-              flexWrap: 'wrap',
+              flexDir: 'column',
+              gap: '6',
+              py: '8',
             })}
           >
-            <div className={css({ display: 'flex', gap: '2', flexWrap: 'wrap' })}>
+            <div
+              className={css({
+                display: 'flex',
+                flexDir: 'row',
+                alignItems: 'center',
+                gap: '2',
+                flexWrap: 'wrap',
+              })}
+            >
               <Button onClick={saveEpub} disabled={isBusy}>
                 {status === 'saving' ? (
                   <span className={css({ display: 'inline-flex', alignItems: 'center', gap: '2' })}>
@@ -513,20 +538,68 @@ export function EpubPage() {
                   'Save EPUB'
                 )}
               </Button>
+              <Button
+                variant="secondary"
+                onClick={reset}
+                disabled={isBusy}
+                className={css({ ml: 'auto' })}
+              >
+                Load Different File
+              </Button>
+            </div>
+
+            <div
+              className={css({
+                display: 'flex',
+                flexDir: 'row',
+                alignItems: 'center',
+                gap: '2',
+                flexWrap: 'wrap',
+              })}
+            >
               <LoadHeadingsButton
                 onClick={loadFromHeadings}
                 disabled={isBusy}
                 loading={status === 'loading-headings'}
               />
+              <label
+                className={css({
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '1.5',
+                  fontSize: 'sm',
+                  color: 'fg.muted',
+                })}
+              >
+                Level:
+                <select
+                  value={headingLevel}
+                  onChange={(e) => setHeadingLevel(e.target.value as HeadingLevelChoice)}
+                  disabled={isBusy}
+                  aria-label="Heading level to look for"
+                  className={css({
+                    px: '2',
+                    py: '1',
+                    border: '1px solid',
+                    borderColor: 'border',
+                    borderRadius: 'sm',
+                    backgroundColor: 'bg.panel',
+                    color: 'fg',
+                    fontSize: 'sm',
+                    cursor: 'pointer',
+                    _disabled: { opacity: 0.5, cursor: 'not-allowed' },
+                  })}
+                >
+                  <option value="any">Any</option>
+                  <option value="1">H1</option>
+                  <option value="2">H2</option>
+                  <option value="3">H3</option>
+                  <option value="4">H4</option>
+                  <option value="5">H5</option>
+                  <option value="6">H6</option>
+                </select>
+              </label>
             </div>
-            <Button
-              variant="secondary"
-              onClick={reset}
-              disabled={isBusy}
-              className={css({ ml: 'auto' })}
-            >
-              Load Different File
-            </Button>
           </div>
 
           <div>

--- a/src/epub/parser.test.ts
+++ b/src/epub/parser.test.ts
@@ -136,6 +136,171 @@ describe('EpubDocument', () => {
     expect(ncxText).toContain('Renamed');
   });
 
+  it('reads Scrivener-style p.heading-N as a heading when no <h*> exists', async () => {
+    const zip = new JSZip();
+    zip.file('mimetype', 'application/epub+zip', { compression: 'STORE' });
+    zip.file('META-INF/container.xml', CONTAINER_XML);
+    zip.file('OEBPS/content.opf', OPF);
+    zip.file('OEBPS/nav.xhtml', NAV);
+    zip.file('OEBPS/toc.ncx', NCX);
+    zip.file(
+      'OEBPS/ch1.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 1</title></head>
+  <body>
+    <p class="heading-2">Subsection Alpha</p>
+    <p>Some content.</p>
+  </body>
+</html>`
+    );
+    zip.file(
+      'OEBPS/ch2.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 2</title></head>
+  <body>
+    <div id="start">
+      <p class="heading-1">Part Two</p>
+      <p class="heading-2">Subsection Beta</p>
+    </div>
+  </body>
+</html>`
+    );
+    const blob = await zip.generateAsync({ type: 'blob', mimeType: 'application/epub+zip' });
+    const file = new File([blob], 'scrivener.epub', { type: 'application/epub+zip' });
+
+    const doc = await EpubDocument.load(file, file.name);
+    const heading1 = await doc.getChapterHeading(doc.chapters[0].id);
+    const heading2 = await doc.getChapterHeading(doc.chapters[1].id);
+    expect(heading1).toBe('Subsection Alpha');
+    expect(heading2).toBe('Part Two');
+  });
+
+  it('prefers a real <h1> over a later p.heading-1 at the same level', async () => {
+    const zip = new JSZip();
+    zip.file('mimetype', 'application/epub+zip', { compression: 'STORE' });
+    zip.file('META-INF/container.xml', CONTAINER_XML);
+    zip.file('OEBPS/content.opf', OPF);
+    zip.file('OEBPS/nav.xhtml', NAV);
+    zip.file('OEBPS/toc.ncx', NCX);
+    zip.file(
+      'OEBPS/ch1.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 1</title></head>
+  <body>
+    <h1>Real Heading First</h1>
+    <p class="heading-1">Scrivener Heading Second</p>
+  </body>
+</html>`
+    );
+    zip.file(
+      'OEBPS/ch2.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 2</title></head>
+  <body>
+    <div id="start">
+      <h1>Real Heading First</h1>
+      <p class="heading-1">Scrivener Heading Second</p>
+    </div>
+  </body>
+</html>`
+    );
+    const blob = await zip.generateAsync({ type: 'blob', mimeType: 'application/epub+zip' });
+    const file = new File([blob], 'mixed.epub', { type: 'application/epub+zip' });
+
+    const doc = await EpubDocument.load(file, file.name);
+    const heading1 = await doc.getChapterHeading(doc.chapters[0].id);
+    const heading2 = await doc.getChapterHeading(doc.chapters[1].id);
+    expect(heading1).toBe('Real Heading First');
+    expect(heading2).toBe('Real Heading First');
+  });
+
+  it('filters heading lookup by level when requested', async () => {
+    const zip = new JSZip();
+    zip.file('mimetype', 'application/epub+zip', { compression: 'STORE' });
+    zip.file('META-INF/container.xml', CONTAINER_XML);
+    zip.file('OEBPS/content.opf', OPF);
+    zip.file('OEBPS/nav.xhtml', NAV);
+    zip.file('OEBPS/toc.ncx', NCX);
+    zip.file(
+      'OEBPS/ch1.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 1</title></head>
+  <body>
+    <p class="heading-1">Part One</p>
+    <p class="heading-2">Subsection Alpha</p>
+    <h1>Real Chapter Title</h1>
+  </body>
+</html>`
+    );
+    zip.file(
+      'OEBPS/ch2.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 2</title></head>
+  <body>
+    <div id="start">
+      <p class="heading-2">Subsection Beta</p>
+      <h1>Another Real Title</h1>
+    </div>
+  </body>
+</html>`
+    );
+    const blob = await zip.generateAsync({ type: 'blob', mimeType: 'application/epub+zip' });
+    const file = new File([blob], 'level.epub', { type: 'application/epub+zip' });
+
+    const doc = await EpubDocument.load(file, file.name);
+
+    expect(await doc.getChapterHeading(doc.chapters[0].id, { level: 1 })).toBe('Part One');
+    expect(await doc.getChapterHeading(doc.chapters[0].id, { level: 2 })).toBe('Subsection Alpha');
+
+    expect(await doc.getChapterHeading(doc.chapters[1].id, { level: 1 })).toBe(
+      'Another Real Title'
+    );
+    expect(await doc.getChapterHeading(doc.chapters[1].id, { level: 2 })).toBe('Subsection Beta');
+  });
+
+  it('returns null when no heading exists at the requested level', async () => {
+    const zip = new JSZip();
+    zip.file('mimetype', 'application/epub+zip', { compression: 'STORE' });
+    zip.file('META-INF/container.xml', CONTAINER_XML);
+    zip.file('OEBPS/content.opf', OPF);
+    zip.file('OEBPS/nav.xhtml', NAV);
+    zip.file('OEBPS/toc.ncx', NCX);
+    zip.file(
+      'OEBPS/ch1.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 1</title></head>
+  <body>
+    <h1>Only an H1</h1>
+    <p>Body text.</p>
+  </body>
+</html>`
+    );
+    zip.file(
+      'OEBPS/ch2.xhtml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter 2</title></head>
+  <body>
+    <div id="start"><h1>Only an H1</h1></div>
+  </body>
+</html>`
+    );
+    const blob = await zip.generateAsync({ type: 'blob', mimeType: 'application/epub+zip' });
+    const file = new File([blob], 'no-h2.epub', { type: 'application/epub+zip' });
+
+    const doc = await EpubDocument.load(file, file.name);
+    expect(await doc.getChapterHeading(doc.chapters[0].id, { level: 2 })).toBeNull();
+    expect(await doc.getChapterHeading(doc.chapters[1].id, { level: 2 })).toBeNull();
+    expect(await doc.getChapterHeading(doc.chapters[0].id, { level: 1 })).toBe('Only an H1');
+  });
+
   it('rejects non-EPUB zip files', async () => {
     const zip = new JSZip();
     zip.file('hello.txt', 'world');

--- a/src/epub/parser.ts
+++ b/src/epub/parser.ts
@@ -94,6 +94,44 @@ function generateId(): string {
   return Math.random().toString(36).substring(2, 12);
 }
 
+/**
+ * Returns the heading "level" (1–6) for an element if it looks like a heading,
+ * or null otherwise. Recognizes real <h1>–<h6> tags as well as <p>/<div>
+ * elements with a class like `heading-1` … `heading-6` (Scrivener exports
+ * use this pattern instead of real heading tags).
+ */
+function getHeadingLevel(el: Element): number | null {
+  const name = el.localName;
+  if (name && /^h[1-6]$/.test(name)) {
+    return Number(name[1]);
+  }
+  if (name === 'p' || name === 'div') {
+    const cls = el.getAttribute('class');
+    if (cls) {
+      const match = cls.match(/(?:^|\s)heading-([1-6])(?=\s|$)/);
+      if (match) return Number(match[1]);
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the first descendant of `root` (in document order) whose heading level
+ * equals `level`. Returns null if none is found.
+ */
+function findHeadingAtLevel(root: Element, level: number): Element | null {
+  const stack: Element[] = [root];
+  while (stack.length) {
+    const el = stack.pop()!;
+    if (getHeadingLevel(el) === level) return el;
+    const children = el.children;
+    for (let i = children.length - 1; i >= 0; i--) {
+      stack.push(children[i]);
+    }
+  }
+  return null;
+}
+
 function parseXml(text: string, mimeType: 'application/xml' | 'application/xhtml+xml'): Document {
   const doc = new DOMParser().parseFromString(text, mimeType);
   const parserError = doc.getElementsByTagName('parsererror');
@@ -299,8 +337,14 @@ export class EpubDocument {
   /**
    * For a given chapter (referenced by id), open its content file and return the
    * first heading's text, or null if none can be found.
+   *
+   * If `level` is set (1–6), only headings at that level are considered;
+   * otherwise levels are tried in order 1→6.
    */
-  async getChapterHeading(chapterId: string): Promise<string | null> {
+  async getChapterHeading(
+    chapterId: string,
+    options: { level?: number } = {}
+  ): Promise<string | null> {
     const chapter = this.internalChapters.find((c) => c.id === chapterId);
     if (!chapter) return null;
 
@@ -323,24 +367,37 @@ export class EpubDocument {
       if (idEl) startElement = idEl;
     }
 
-    for (const tag of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
-      const headings = getAllByLocalName(startElement, tag);
-      if (headings.length > 0) {
-        const heading = headings[0].textContent?.replace(/\s+/g, ' ').trim();
-        if (heading) return heading;
+    const levels =
+      options.level && options.level >= 1 && options.level <= 6
+        ? [options.level]
+        : [1, 2, 3, 4, 5, 6];
+
+    for (const level of levels) {
+      const heading = findHeadingAtLevel(startElement, level);
+      if (heading) {
+        const text = heading.textContent?.replace(/\s+/g, ' ').trim();
+        if (text) return text;
       }
     }
 
     if (fragment) {
-      for (const tag of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
-        const headings = getAllByLocalName(doc, tag);
-        for (const h of headings) {
-          if (
-            startElement === h ||
-            startElement.compareDocumentPosition(h) & Node.DOCUMENT_POSITION_FOLLOWING
-          ) {
-            const heading = h.textContent?.replace(/\s+/g, ' ').trim();
-            if (heading) return heading;
+      const root = doc.documentElement;
+      for (const level of levels) {
+        const stack: Element[] = [root];
+        while (stack.length) {
+          const el = stack.pop()!;
+          if (getHeadingLevel(el) === level) {
+            if (
+              startElement === el ||
+              startElement.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING
+            ) {
+              const text = el.textContent?.replace(/\s+/g, ' ').trim();
+              if (text) return text;
+            }
+          }
+          const children = el.children;
+          for (let i = children.length - 1; i >= 0; i--) {
+            stack.push(children[i]);
           }
         }
       }


### PR DESCRIPTION
## Summary

- Heading detection in the EPUB chapter renamer now also accepts `<p class=\"heading-1\">` … `<p class=\"heading-6\">` (and the same on `<div>`), which is what Scrivener emits instead of real `<h1>`–`<h6>` tags. First match at each level in document order wins, so real heading tags still take precedence when they come first.
- Added a **Level** dropdown next to *Load from Chapter Headings* (Any / H1–H6). Picking a specific level limits the lookup; chapters with no matching heading at the chosen level keep their existing name.
- Reorganized the action row: Save EPUB + Load Different File on one row, Load from Chapter Headings + Level on a second row, with more vertical breathing room around the block.

## Test plan
- [x] `bun run test src/epub/parser.test.ts` — 9 tests pass, including new coverage for Scrivener-style paragraphs, h1-precedence, level filtering, and null when no heading exists at the requested level.
- [x] `bun run lint` clean.
- [x] Manual: load a Scrivener-exported EPUB, click Load from Chapter Headings with Level = Any, then H2; confirm chapters update correctly and that unmatched chapters keep their existing names.